### PR TITLE
Fix segmentation violation

### DIFF
--- a/run_hmm.c
+++ b/run_hmm.c
@@ -1,5 +1,6 @@
 #include "hmm.h"
 #include "run_hmm.h"
+#include "config.h"  // TODO Missing include for PKGDATADIR?
 #include "translation_tables.h"
 #include "util_lib.h"
 

--- a/run_hmm.c
+++ b/run_hmm.c
@@ -1,6 +1,5 @@
 #include "hmm.h"
 #include "run_hmm.h"
-#include "config.h"  // TODO Missing include for PKGDATADIR?
 #include "translation_tables.h"
 #include "util_lib.h"
 


### PR DESCRIPTION
## Problem description:
Segmentation violation when processing an input DNA sequence where two or more probable 
single nucleotide deletions are identified during ORF prediction

A segmentation violation has been seen in print_gene() in hmm_lib.c, caused by a corrupted
temp_str_ptr parameter value being passed by viterbi(). In optimized viterbi() code,
temp_str_ptr can be located in storage directly after the dna_seq array. viterbi() unfortunately
can write beyond the end of dna_seq if the sequence requires that placeholder N/NUCL_INVALID
values be inserted into dna_seq to represent missing nucleotides. When the code writes past
the end of dna_seq, it can overwrite the value of temp_str_ptr. Then when an attempt is made
to dereference the corrupted temp_str_ptr (such as in print_gene()), a segmentation violation
occurs.

## Proposed solution:
A fix is to dynamically grow dna_seq if more data needs to be stored there than originally
anticipated. Generally, sequences are not found to have probable missing nucleotides, but 
a robust solution should accommodate the addition of potentially a large number of missing 
nucleotides. To avoid impacting performance for standard cases, the initial buffer for 
dna_seq will continue to be allocated from the stack but will have its size increased by 
10%. If, during the course of processing a sequence, a larger buffer for dna_seq is needed, 
a new buffer will be dynamically allocated and the existing contents copied to the new 
buffer. This part of the solution is expected to be an outlier case that is rarely encountered 
and so will have limited performance impact. 

```
# -- Below writes to dna_seq[dna_id] can write past the end of dna_seq[].
# -- For the optimized case that fails, an "optimized" value for &temp_str_ptr (stored as a
# -- local variable at $bp-0x1c0) is passed to print_gene() instead of the address of the
# -- temp_str_ptr parameter. The local variable is overwritten when viterbi() writes past
#        } else if (strand != UNKNOWN_STRAND &&
# -- the end of the dna_seq array, after a placeholder N/NUCL_INVALID value is inserted by
# -- the for loop at line 833 when out_nt is greater than 1 (to represent a suspected missing
# -- nucleotide), because dna_seq is not sized to accommodate any extra values.
#                   ((vpath[t] >= M1_STATE && vpath[t] <= M6_STATE) ||
#                    (vpath[t] >= M1_STATE_1 && vpath[t] <= M6_STATE_1)) &&
#                   vpath[t] - prev_match < 6) {
#
#            out_nt = vpath[t]-prev_match;
#            if (vpath[t] < prev_match)
#                out_nt += 6;
#
# 833 >>     for (kk = 0; kk < out_nt; kk++) {  /* for deleted nt in reads */
#                dna_id ++;
#                dna[dna_id] = 'N';
# 836 >>         dna_seq[dna_id] = NUCL_INVALID;
#                if (kk>0) {
#                    deletions[nr_deletions] = t+1;
#                    nr_deletions++;
#                }
#            }
#            dna[dna_id] = O[t];
# 843 >>     dna_seq[dna_id] = sequence[t];
#            prev_match = vpath[t];

# -- Memory has already been changed by line 790
```